### PR TITLE
Changed callbacks to node.js style

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ var darksky = require("darksky");
 var client = darksky.Client("mykey");
   
 client.forecast('37.8267','-122.423', 
-    function(data) {
+    function(err, data) {
+        if (err) {
+            console.error(err);
+        }
         process.stdout.write(data);
-    },
-    function(err) {
-        console.error(err);
     }
 );
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,7 @@ function Client(api_key)
   this.api_key = api_key;
 }
 
-Client.prototype.call = function(options, callback, error)
+Client.prototype.call = function(options, callback)
 {
   // Support function to run an HTTPS query against the API
   //
@@ -27,25 +27,20 @@ Client.prototype.call = function(options, callback, error)
   var req = https.request(options, function(res) {
     // console.log("status: ", res.statusCode);
     // console.log("headers: ", res.headers);
-
-    if( callback ) {
       res.on('data', function(d) {
-        callback( d );
+        callback(null, d);
       });
-    }
 
   });
-
-  if( error ) {
-    req.on('error', function(e) {
-      error(e);
-    });
-  }
+  
+  req.on('error', function(e) {
+    callback(e);
+  });
 
   req.end();
 };
 
-Client.prototype.forecast = function(latitude, longitude, callback, error)
+Client.prototype.forecast = function(latitude, longitude, callback)
 {
   // Fetch the forecast for a given latitutde and longitude in decimal
   // degrees
@@ -63,10 +58,10 @@ Client.prototype.forecast = function(latitude, longitude, callback, error)
     method : 'GET'
   };
 
-  this.call(options, callback, error);
+  this.call(options, callback);
 };
 
-Client.prototype.brief_forecast = function(latitude, longitude, callback, error)
+Client.prototype.brief_forecast = function(latitude, longitude, callback)
 {
   // Fetch the brief forecast for a given latitutde and longitude in decimal
   // degrees
@@ -84,10 +79,10 @@ Client.prototype.brief_forecast = function(latitude, longitude, callback, error)
     method : 'GET'
   };
 
-  this.call(options, callback, error);
+  this.call(options, callback);
 };
 
-Client.prototype.precipitation = function(points, callback, error)
+Client.prototype.precipitation = function(points, callback)
 {
   // Fetch forecasts for multiple points and times. Points should be an
   // array containing triplets of [latitude, longitute, time], where
@@ -110,10 +105,10 @@ Client.prototype.precipitation = function(points, callback, error)
     method : 'GET'
   };
 
-  this.call(options, callback, error);
+  this.call(options, callback);
 };
 
-Client.prototype.interesting = function(callback, error)
+Client.prototype.interesting = function(callback)
 {
   // Fetch forecasts for interesting storms happening right now
   // http://darkskyapp.com/api/interesting.html
@@ -128,7 +123,7 @@ Client.prototype.interesting = function(callback, error)
     method : 'GET'
   };
 
-  this.call(options, callback, error);
+  this.call(options, callback);
 };
 
 exports.Client = Client;

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -21,23 +21,20 @@ it("should create a client with api key set", function() {
 
 it("should call https request and all optional callbacks", function() {
   var callback = jasmine.createSpy();
-  var error = jasmine.createSpy();
   var request = {
     on : jasmine.createSpy(),
     end : jasmine.createSpy()
   };
   spyOn( callback, "call" );
-  spyOn( error, "call");
   var request_spy = spyOn( https, "request");
   request_spy.andReturn( request );
 
-  client.call("options", callback, error);
+  client.call("options", callback);
   // TODO: jasmine should support this style of call!
   // expect( https.request ).toHaveBeenCalledWith(["options", Function]);
   
   // Assert all the calls that would have happened
   expect( request_spy.argsForCall[0][0] ).toEqual("options");
-  expect( request.on.argsForCall[0][0] ).toEqual("error");
   expect( request.end ).toHaveBeenCalled();
   
   // Call the request callback to assert that it registers for data
@@ -50,15 +47,10 @@ it("should call https request and all optional callbacks", function() {
   // Call the data callback to assert that it calls our callback
   result.on.argsForCall[0][1]("data");
   expect( callback ).toHaveBeenCalledWith("data");
-
-  // Call the error callback to assert that it calls our callback
-  request.on.argsForCall[0][1]("error");
-  expect( error ).toHaveBeenCalledWith("error");
 });
 
 it("should call https request without optional callbacks", function() {
   var callback = jasmine.createSpy();
-  var error = jasmine.createSpy();
   var request = {
     on : jasmine.createSpy(),
     end : jasmine.createSpy()
@@ -89,7 +81,7 @@ it("should call https request without optional callbacks", function() {
 it("should fetch the forecast", function()
 {
   var call = spyOn( client, "call" );
-  client.forecast("3.14", "1.42", "callback", "error");
+  client.forecast("3.14", "1.42", "callback");
   
   expect( call ).toHaveBeenCalledWith(
     {
@@ -97,14 +89,14 @@ it("should fetch the forecast", function()
       port : 443,
       path : "/v1/forecast/api_key/3.14,1.42",
       method : 'GET'
-    }, "callback", "error"
+    }, "callback"
   );
 });
 
 it("should fetch the brief forecast", function()
 {
   var call = spyOn( client, "call" );
-  client.brief_forecast("3.14", "1.42", "callback", "error");
+  client.brief_forecast("3.14", "1.42", "callback");
   
   expect( call ).toHaveBeenCalledWith(
     {
@@ -112,7 +104,7 @@ it("should fetch the brief forecast", function()
       port : 443,
       path : "/v1/brief_forecast/api_key/3.14,1.42",
       method : 'GET'
-    }, "callback", "error"
+    }, "callback"
   );
 });
 
@@ -127,7 +119,7 @@ it("should fetch the precipitation for a single location", function()
       port : 443,
       path : "/v1/precipitation/api_key/3.14,1.42,now",
       method : 'GET'
-    }, "callback", "error"
+    }, "callback"
   );
 });
 
@@ -142,7 +134,7 @@ it("should fetch the precipitation for multiple locations", function()
       port : 443,
       path : "/v1/precipitation/api_key/3.14,1.42,now;4.23,-7.58,soon",
       method : 'GET'
-    }, "callback", "error"
+    }, "callback"
   );
 });
 
@@ -157,7 +149,7 @@ it("should fetch interesting weather", function()
       port : 443,
       path : "/v1/interesting/api_key",
       method : 'GET'
-    }, "callback", "error"
+    }, "callback"
   );
 });
 


### PR DESCRIPTION
The common node.js pattern is for errors to be handled by the callback function and have the first parameter be the error, either the error itself or null. Some common examples of this are the request and async modules.
